### PR TITLE
Update to fix typo from app-tractographyQualityCheck

### DIFF
--- a/validate.py
+++ b/validate.py
@@ -43,7 +43,7 @@ if not os.path.exists(config["csv"]):
 if not os.path.exists(config["csv"]):
     results["errors"].append("csv[%s] file does not exist" % config["csv"])
 else:
-    tmp = pd.read_csv(config["csv"])
+    tmp = pandas.read_csv(config["csv"])
     if 'avgerageStreamlineLength' in tmp.keys():
         tmp.rename(columns={'avgerageStreamlineLength': 'averageStreamlineLength'},inplace=True)
         tmp.to_csv("output/tractmeasures.csv",index=False)

--- a/validate.py
+++ b/validate.py
@@ -43,7 +43,10 @@ if not os.path.exists(config["csv"]):
 if not os.path.exists(config["csv"]):
     results["errors"].append("csv[%s] file does not exist" % config["csv"])
 else:
-
+    tmp = pd.read_csv(config["csv"])
+    if 'avgerageStreamlineLength' in tmp.keys():
+        tmp.rename(columns={'avgerageStreamlineLength': 'averageStreamlineLength'},inplace=True)
+        tmp.to_csv("output/tractmeasures.csv",index=False)
     #with open(config["csv"]) as csvfile:
     #    reader = csv.reader(csvfile)
     #    header = next(reader, None)


### PR DESCRIPTION
Like with the old datatype filename, we need to update a column name in the tractmeasures:macro datatype specifically from app-tractographyQualityCheck. Specifically, it loads the config['csv'] and checks if the typo exists in the keys. If so, will fix the typo by changing the column name to "averageStreamlineLength" from "avgerageStreamlineLength".

I've pushed a PR to the tractography quality check app but need to wait for Dan to update the app.

This will provide an immediate fix.